### PR TITLE
Ver 1.4.0

### DIFF
--- a/MLRSDamage.cs
+++ b/MLRSDamage.cs
@@ -84,8 +84,12 @@ namespace Oxide.Plugins
         {
             ConsoleSystem.Run(ConsoleSystem.Option.Server, "MLRS.brokenDownMinutes 10");
             Puts("MLRS cooldown time reset to 10 minutes");
-            SetRocketSize(12);
-            Puts("MLRS total rockets to fire reset to 12");
+            
+            if (StackSizeController == null)
+            {
+                SetRocketSize(12);
+                Puts("MLRS total rockets to fire reset to 12");
+            }
             foreach (var entity in UnityEngine.Object.FindObjectsOfType<MLRS>())
             {
                 StorageContainer dashboardContainer = entity.GetDashboardContainer();
@@ -97,7 +101,14 @@ namespace Oxide.Plugins
         private void Loaded()
         {
             ConsoleSystem.Run(ConsoleSystem.Option.Server, $"MLRS.brokenDownMinutes {_config.defsettings.broken}"); //Sets MLRS cooldown timer
-            SetRocketSize(_config.defsettings.rocketAmount);
+
+            if (StackSizeController != null)
+            {
+                Puts($"StackSizeController detected. Setting rocketAmount to {(int)StackSizeController.Call("GetStackSize", -1843426638) * 2}");
+                _config.defsettings.rocketAmount = (int)StackSizeController.Call("GetStackSize", -1843426638) * 2;
+                SaveConfig();
+            }
+            else SetRocketSize(_config.defsettings.rocketAmount);
 
             foreach (var entity in UnityEngine.Object.FindObjectsOfType<MLRS>())
             {


### PR DESCRIPTION
- Adds ability to change launch interval of rockets.
  -- Must be above zero. Adds caution message if timer is set between 0 and 0.1.
- Adds ability to disable need for aiming module.
  -- Setting to False keeps an AimingModule in the MLRS all the time, and locks the inventory to keep people from looting it.
- Adds console commands for the two new features.
  -- commands are mlrsdamage.module (true/false) and mlrsdamage.interval (int).
- Adds in new checks for BaseNpc and BaseAnimalNPC in the OnEntityTakeDamage hook.
- Fixes stack size issues.
  -- Integrates with StackSizeController.