### PR TITLE
Addresses Index error

### DIFF
--- a/MLRSDamage.cs
+++ b/MLRSDamage.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("MLRS Damage", "iLakSkiL", "1.5.0")]
+    [Info("MLRS Damage", "iLakSkiL", "1.5.1")]
     [Description("Edits the damage down by the MLRS.")]
     public class MLRSDamage : RustPlugin
     {
@@ -179,7 +179,7 @@ namespace Oxide.Plugins
             }
             if (ent.RocketAmmoCount > 12)
             {
-                ent.nextRocketIndex = (int)((ent.RocketAmmoCount % 12) + 1);
+                ent.nextRocketIndex = (int)((ent.RocketAmmoCount % 11) + 1);
                 rocketsFired++;
                 return;
             }
@@ -197,7 +197,7 @@ namespace Oxide.Plugins
             ent.radiusModIndex = 0;
             if (ent.RocketAmmoCount > 12)
             {
-                ent.nextRocketIndex = (int)((ent.RocketAmmoCount % 12) + 1);
+                ent.nextRocketIndex = (int)((ent.RocketAmmoCount % 11) + 1);
             }
             else ent.nextRocketIndex = ent.RocketAmmoCount - 1;
             ent.rocketOwnerRef.Set(owner);

--- a/MLRSDamage.cs
+++ b/MLRSDamage.cs
@@ -214,7 +214,7 @@ namespace Oxide.Plugins
 
         #endregion
 
-            #region Helpers
+        #region Helpers
 
         public void SetRocketAmount(int amount)
         {


### PR DESCRIPTION
- Attempts to address rare issue when loading an odd-number of rockets causes the MLRS to not fire and throw an IndexOutOfRangeException error.